### PR TITLE
feat: add configuration files to fix image bug in deploy previews

### DIFF
--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,0 +1,140 @@
+# This is the default format.
+# For more see: https://github.com/mojombo/jekyll/wiki/Permalinks
+permalink: /:year-:month/:title
+
+exclude: [".rvmrc", ".rbenv-version", "README.md", "Rakefile", "changelog.md", "node_modules", "src"]
+# auto: true
+gems:
+  - jekyll-redirect-from
+highlander: true
+markdown: kramdown
+sass:
+    sass_dir: _sass
+
+# Themes are encouraged to use these universal variables
+# so be sure to set them if your theme uses them.
+#
+title : Nomad As Fuck
+tagline: Showcasing the most badass nomads on the planet.
+author :
+  name : Nomad As Fuck
+  email : richard@nomadasfuck.com
+  github : RichardLitt
+  twitter : "@nomadasfuck"
+  #feedburner : feedname
+
+git_remote : git@github.com:RichardLitt/nomad-as-fuck.git
+github : https://github.com/RichardLitt/nomad-as-fuck
+
+collections:
+  authors:
+    output: true
+    permalink: author/:path/
+
+# The production_url is only used when full-domain names are needed
+# such as sitemap.txt
+# Most places will/should use BASE_PATH to make the urls
+#
+# If you have set a CNAME (pages.github.com) set your custom domain here.
+# Else if you are pushing to username.github.com, replace with your username.
+# Finally if you are pushing to a GitHub project page, include the project name at the end.
+#
+url:
+production_url : https://nomadasfuck.com
+
+# All Jekyll-Bootstrap specific configurations are namespaced into this hash
+#
+JB :
+  version : 0.2.13
+
+  # All links will be namespaced by BASE_PATH if defined.
+  # Links in your website should always be prefixed with {{BASE_PATH}}
+  # however this value will be dynamically changed depending on your deployment situation.
+  #
+  # CNAME (http://yourcustomdomain.com)
+  #   DO NOT SET BASE_PATH
+  #   (urls will be prefixed with "/" and work relatively)
+  #
+  # GitHub Pages (http://username.github.com)
+  #   DO NOT SET BASE_PATH
+  #   (urls will be prefixed with "/" and work relatively)
+  #
+  # GitHub Project Pages (http://username.github.com/project-name)
+  #
+  #   A GitHub Project site exists in the `gh-pages` branch of one of your repositories.
+  #  REQUIRED! Set BASE_PATH to: http://username.github.com/project-name
+  #
+  # CAUTION:
+  #   - When in Localhost, your site will run from root "/" regardless of BASE_PATH
+  #   - Only the following values are falsy: ["", null, false]
+  #   - When setting BASE_PATH it must be a valid url.
+  #     This means always setting the protocol (http|https) or prefixing with "/"
+  BASE_PATH : false
+
+  # By default, the asset_path is automatically defined relative to BASE_PATH plus the enabled theme.
+  # ex: [BASE_PATH]/assets/themes/[THEME-NAME]
+  #
+  # Override this by defining an absolute path to assets here.
+  # ex:
+  #   http://s3.amazonaws.com/yoursite/themes/watermelon
+  #   /assets
+  #
+  ASSET_PATH : false
+
+  # These paths are to the main pages Jekyll-Bootstrap ships with.
+  # Some JB helpers refer to these paths; change theme here if needed.
+  #
+  archive_path: /archive.html
+  categories_path : /categories.html
+  tags_path : /tags.html
+
+  # Settings for comments helper
+  # Set 'provider' to the comment provider you want to use.
+  # Set 'provider' to false to turn commenting off globally.
+  #
+  comments :
+    provider : disqus
+    disqus :
+      short_name : richardlitt
+    livefyre :
+      site_id : 123
+    intensedebate :
+      account : 123abc
+    facebook:
+      appid : 289508827791353
+      num_posts: 5
+      width: 580
+      colorscheme: light
+
+  # Settings for analytics helper
+  # Set 'provider' to the analytics provider you want to use.
+  # Set 'provider' to false to turn analytics off globally.
+  #
+  analytics :
+    provider : google
+    # I set this manually in ga.js
+    google :
+        tracking_id : 'UA-4124866-43'
+    #getclicky :
+      #site_id :
+    #mixpanel :
+        #token : '_MIXPANEL_TOKEN_'
+
+  # Settings for sharing helper.
+  # Sharing is for things like tweet, plusone, like, reddit buttons etc.
+  # Set 'provider' to the sharing provider you want to use.
+  # Set 'provider' to false to turn sharing off globally.
+  #
+  sharing :
+    provider : twitter
+
+  # Settings for all other include helpers can be defined by creating
+  # a hash with key named for the given helper. ex:
+  #
+  #   pages_list :
+  #     provider : "custom"
+  #
+  # Setting any helper's provider to 'custom' will bypass the helper code
+  # and include your custom code. Your custom file must be defined at:
+  #   ./_includes/custom/[HELPER]
+  # where [HELPER] is the name of the helper you are overriding.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[context.deploy-preview]
+command = "gulp && jekyll build --safe --config _config_dev.yml"
+
+[context.branch-deploy]
+command = "gulp && jekyll build --safe --config _config_dev.yml"


### PR DESCRIPTION
Basically, this PR tricks netlify to serve relative paths by setting site url to empty during preview deploys.  
- Add _config_dev.yml which changes url from www.nomadasfuck.com to ""
- Add netlify.toml which builds the site with _config_dev.yml in branch and preview deploys. 